### PR TITLE
add first `erc20` e2e test (FAILS)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ r = "run -- --dev -lerror,ethin=debug"
 
 [env]
 FLIPPER_PATH = { value = "dapp/contracts/flipper.ink/Cargo.toml", relative = true, force = true }
+ERC20_PATH = { value = "dapp/contracts/erc20.ink/Cargo.toml", relative = true, force = true }
 ALITH_ADDRESS = "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
 ALITH_KEY = "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133"
 BALTATHAR_ADDRESS = "0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -670,7 +670,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1037,7 +1037,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1470,7 +1470,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1487,7 +1487,7 @@ checksum = "b404f596046b0bb2d903a9c786b875a126261b52b7c3a64bbb66382c41c771df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1557,7 +1557,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1588,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1639,6 +1639,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1737,7 +1748,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1759,26 +1770,26 @@ dependencies = [
 
 [[package]]
 name = "docify"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc4fd38aaa9fb98ac70794c82a00360d1e165a87fbf96a8a91f9dfc602aaee2"
+checksum = "43a2f138ad521dc4a2ced1a4576148a6a610b4c5923933b062a263130a6802ce"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa215f3a0d40fb2a221b3aa90d8e1fbb8379785a990cb60d62ac71ebdc6460"
+checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
 dependencies = [
  "common-path",
- "derive-syn-parse",
+ "derive-syn-parse 0.2.0",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.55",
+ "syn 2.0.58",
  "termcolor",
  "toml 0.8.2",
  "walkdir",
@@ -2223,7 +2234,7 @@ checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2233,7 +2244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2256,7 +2267,7 @@ dependencies = [
  "prettier-please",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2400,7 +2411,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2435,7 +2446,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2460,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.2",
@@ -2508,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2550,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-recursion",
  "futures",
@@ -2572,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -2612,11 +2623,11 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "Inflector",
  "cfg-expr",
- "derive-syn-parse",
+ "derive-syn-parse 0.1.5",
  "expander",
  "frame-support-procedural-tools",
  "itertools",
@@ -2624,35 +2635,35 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -2671,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2680,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2770,7 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -2781,7 +2792,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2826,7 +2837,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "pin-utils",
  "slab",
 ]
@@ -3165,7 +3176,7 @@ checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
 ]
 
 [[package]]
@@ -3208,7 +3219,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "socket2 0.5.6",
  "tokio",
  "tower-service",
@@ -4144,13 +4155,12 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -4344,7 +4354,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4354,11 +4364,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e766a20fd9c72bab3e1e64ed63f36bd08410e75803813df210d1ce297d7ad00"
 dependencies = [
  "const-random",
- "derive-syn-parse",
+ "derive-syn-parse 0.1.5",
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4369,7 +4379,7 @@ checksum = "d710e1214dffbab3b5dacb21475dde7d6ed84c69ff722b3a47a782668d44fbac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4380,7 +4390,7 @@ checksum = "b8fb85ec1620619edf2984a7693497d4ec88a9665d8b87e942856884c92dbf2a"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4622,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4541eb06dce09c0241ebbaab7102f0a01a0c8994afed2e5d0d66775016e25ac2"
+checksum = "3ea4908d4f23254adda3daa60ffef0f1ac7b8c3e9a864cf3cc154b251908a2ef"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -4711,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
  "bytes",
  "futures",
@@ -4893,7 +4903,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4909,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4926,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4940,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4955,13 +4965,14 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "impl-trait-for-tuples",
  "log",
  "pallet-balances",
@@ -4984,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "24.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -4997,11 +5008,11 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5028,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5051,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5065,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5087,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5102,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5121,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5137,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5153,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5165,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5344,9 +5355,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5355,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5365,22 +5376,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
 dependencies = [
  "once_cell",
  "pest",
@@ -5414,7 +5425,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5425,9 +5436,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -5466,7 +5477,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.3.9",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "rustix 0.38.32",
  "tracing",
  "windows-sys 0.52.0",
@@ -5550,7 +5561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
 dependencies = [
  "proc-macro2",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5570,7 +5581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5639,7 +5650,7 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5685,7 +5696,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5961,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.12",
  "libredox",
@@ -5987,7 +5998,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6390,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "log",
  "sp-core 21.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
@@ -6401,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6424,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6439,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -6458,18 +6469,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "chrono",
@@ -6508,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "fnv",
  "futures",
@@ -6534,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -6560,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -6585,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -6614,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.2",
@@ -6655,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -6678,7 +6689,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -6700,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -6712,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6729,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ansi_term",
  "futures",
@@ -6745,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "parking_lot 0.12.1",
@@ -6759,7 +6770,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -6800,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-channel",
  "cid",
@@ -6820,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -6837,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -6855,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -6876,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel",
@@ -6910,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -6928,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "bytes",
@@ -6962,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6971,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -7002,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7021,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -7036,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "futures",
@@ -7064,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "directories",
@@ -7128,7 +7139,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7139,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "futures",
  "libc",
@@ -7158,7 +7169,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "chrono",
  "futures",
@@ -7177,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ansi_term",
  "atty",
@@ -7206,18 +7217,18 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -7243,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -7259,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-channel",
  "futures",
@@ -7504,9 +7515,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -7517,9 +7528,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7575,7 +7586,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7800,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -7821,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "Inflector",
  "blake2",
@@ -7829,7 +7840,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7849,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7877,7 +7888,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7891,7 +7902,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -7902,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "futures",
  "log",
@@ -7920,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "futures",
@@ -7935,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7952,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7971,7 +7982,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7989,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8046,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "array-bytes 6.2.2",
  "arrayvec 0.7.4",
@@ -8108,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -8121,17 +8132,17 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "quote",
  "sp-core-hashing 9.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8145,17 +8156,17 @@ checksum = "c7f531814d2f16995144c74428830ccf7d94ff4a7749632b83ad8199b181140c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8173,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8184,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -8195,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8236,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.1.1",
@@ -8260,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "lazy_static",
  "sp-core 21.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
@@ -8285,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8297,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -8306,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -8317,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "sp-api",
  "sp-core 21.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
@@ -8338,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -8348,7 +8359,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8381,7 +8392,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8422,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -8447,25 +8458,25 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8480,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8515,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -8536,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -8566,7 +8577,7 @@ checksum = "53458e3c57df53698b3401ec0934bea8e8cfce034816873c0b0abbd83d7bac0d"
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 
 [[package]]
 name = "sp-storage"
@@ -8585,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8598,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8624,7 +8635,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "sp-std 8.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
@@ -8636,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "sp-api",
  "sp-runtime 24.0.0 (git+https://github.com/agryaznov/polkadot-sdk?branch=ethink)",
@@ -8645,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8684,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ahash 0.8.11",
  "hash-db 0.16.0",
@@ -8707,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8724,12 +8735,12 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8749,7 +8760,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -8778,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8886,9 +8897,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -8928,7 +8939,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8947,12 +8958,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -8971,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "hyper",
  "log",
@@ -8983,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -8996,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -9066,7 +9077,7 @@ dependencies = [
  "quote",
  "scale-info",
  "subxt-metadata",
- "syn 2.0.55",
+ "syn 2.0.58",
  "thiserror",
  "tokio",
 ]
@@ -9080,7 +9091,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro-error",
  "subxt-codegen",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9109,9 +9120,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9207,7 +9218,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9321,9 +9332,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -9331,7 +9342,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
@@ -9346,7 +9357,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9377,7 +9388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tokio",
  "tokio-util",
 ]
@@ -9392,7 +9403,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tokio",
  "tracing",
 ]
@@ -9489,7 +9500,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tower-layer",
  "tower-service",
 ]
@@ -9513,7 +9524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
- "pin-project-lite 0.2.13",
+ "pin-project-lite 0.2.14",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -9526,7 +9537,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9680,7 +9691,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#f520356fa7b359b6c0555b24b36b79ff594fcf1a"
+source = "git+https://github.com/agryaznov/polkadot-sdk?branch=ethink#53f2846579770d4c7c2c3c3748cba97c1555ef6b"
 dependencies = [
  "async-trait",
  "clap",
@@ -9934,7 +9945,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -9968,7 +9979,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10741,7 +10752,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -10761,7 +10772,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
     "primitives/crypto",
     "frame/ethink",
 ]
-exclude = [ "dapp/contracts/flipper.ink" ]
+exclude = [ "dapp/contracts/flipper.ink", "dapp/contracts/erc20.ink" ]
 resolver = "2"
 
 [workspace.dependencies]

--- a/dapp/contracts/erc20.ink/.gitignore
+++ b/dapp/contracts/erc20.ink/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/dapp/contracts/erc20.ink/Cargo.toml
+++ b/dapp/contracts/erc20.ink/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "erc20"
+version = "4.2.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { git = "https://github.com/agryaznov/ink", branch = "ethink", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+ink_e2e = { git = "https://github.com/agryaznov/ink", branch = "ethink" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/dapp/contracts/erc20.ink/lib.rs
+++ b/dapp/contracts/erc20.ink/lib.rs
@@ -1,0 +1,675 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod erc20 {
+    use ink::storage::Mapping;
+
+    /// A simple ERC-20 contract.
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct Erc20 {
+        /// Total token supply.
+        total_supply: Balance,
+        /// Mapping from owner to number of owned token.
+        balances: Mapping<AccountId, Balance>,
+        /// Mapping of the token amount which an account is allowed to withdraw
+        /// from another account.
+        allowances: Mapping<(AccountId, AccountId), Balance>,
+    }
+
+    /// Event emitted when a token transfer occurs.
+    #[ink(event)]
+    pub struct Transfer {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        value: Balance,
+    }
+
+    /// Event emitted when an approval occurs that `spender` is allowed to withdraw
+    /// up to the amount of `value` tokens from `owner`.
+    #[ink(event)]
+    pub struct Approval {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        spender: AccountId,
+        value: Balance,
+    }
+
+    /// The ERC-20 error types.
+    #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        /// Returned if not enough balance to fulfill a request is available.
+        InsufficientBalance,
+        /// Returned if not enough allowance to fulfill a request is available.
+        InsufficientAllowance,
+    }
+
+    /// The ERC-20 result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    impl Erc20 {
+        /// Creates a new ERC-20 contract with the specified initial supply.
+        #[ink(constructor)]
+        pub fn new(total_supply: Balance) -> Self {
+            let mut balances = Mapping::default();
+            let caller = Self::env().caller();
+            balances.insert(caller, &total_supply);
+            Self::env().emit_event(Transfer {
+                from: None,
+                to: Some(caller),
+                value: total_supply,
+            });
+            Self {
+                total_supply,
+                balances,
+                allowances: Default::default(),
+            }
+        }
+
+        /// Returns the total token supply.
+        #[ink(message)]
+        pub fn total_supply(&self) -> Balance {
+            self.total_supply
+        }
+
+        /// Returns the account balance for the specified `owner`.
+        ///
+        /// Returns `0` if the account is non-existent.
+        #[ink(message)]
+        pub fn balance_of(&self, owner: AccountId) -> Balance {
+            self.balance_of_impl(&owner)
+        }
+
+        /// Returns the account balance for the specified `owner`.
+        ///
+        /// Returns `0` if the account is non-existent.
+        ///
+        /// # Note
+        ///
+        /// Prefer to call this method over `balance_of` since this
+        /// works using references which are more efficient in Wasm.
+        #[inline]
+        fn balance_of_impl(&self, owner: &AccountId) -> Balance {
+            self.balances.get(owner).unwrap_or_default()
+        }
+
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set.
+        #[ink(message)]
+        pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+            self.allowance_impl(&owner, &spender)
+        }
+
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set.
+        ///
+        /// # Note
+        ///
+        /// Prefer to call this method over `allowance` since this
+        /// works using references which are more efficient in Wasm.
+        #[inline]
+        fn allowance_impl(&self, owner: &AccountId, spender: &AccountId) -> Balance {
+            self.allowances.get((owner, spender)).unwrap_or_default()
+        }
+
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the caller's account balance.
+        #[ink(message)]
+        pub fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
+            let from = self.env().caller();
+            self.transfer_from_to(&from, &to, value)
+        }
+
+        /// Allows `spender` to withdraw from the caller's account multiple times, up to
+        /// the `value` amount.
+        ///
+        /// If this function is called again it overwrites the current allowance with
+        /// `value`.
+        ///
+        /// An `Approval` event is emitted.
+        #[ink(message)]
+        pub fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
+            let owner = self.env().caller();
+            self.allowances.insert((&owner, &spender), &value);
+            self.env().emit_event(Approval {
+                owner,
+                spender,
+                value,
+            });
+            Ok(())
+        }
+
+        /// Transfers `value` tokens on the behalf of `from` to the account `to`.
+        ///
+        /// This can be used to allow a contract to transfer tokens on ones behalf and/or
+        /// to charge fees in sub-currencies, for example.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientAllowance` error if there are not enough tokens allowed
+        /// for the caller to withdraw from `from`.
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the account balance of `from`.
+        #[ink(message)]
+        pub fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            let allowance = self.allowance_impl(&from, &caller);
+            if allowance < value {
+                return Err(Error::InsufficientAllowance)
+            }
+            self.transfer_from_to(&from, &to, value)?;
+            self.allowances
+                .insert((&from, &caller), &(allowance - value));
+            Ok(())
+        }
+
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the caller's account balance.
+        fn transfer_from_to(
+            &mut self,
+            from: &AccountId,
+            to: &AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let from_balance = self.balance_of_impl(from);
+            if from_balance < value {
+                return Err(Error::InsufficientBalance)
+            }
+
+            self.balances.insert(from, &(from_balance - value));
+            let to_balance = self.balance_of_impl(to);
+            self.balances.insert(to, &(to_balance + value));
+            self.env().emit_event(Transfer {
+                from: Some(*from),
+                to: Some(*to),
+                value,
+            });
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use ink::primitives::{
+            Clear,
+            Hash,
+        };
+
+        type Event = <Erc20 as ::ink::reflect::ContractEventBase>::Type;
+
+        fn assert_transfer_event(
+            event: &ink::env::test::EmittedEvent,
+            expected_from: Option<AccountId>,
+            expected_to: Option<AccountId>,
+            expected_value: Balance,
+        ) {
+            let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
+                .expect("encountered invalid contract event data buffer");
+            if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
+                assert_eq!(from, expected_from, "encountered invalid Transfer.from");
+                assert_eq!(to, expected_to, "encountered invalid Transfer.to");
+                assert_eq!(value, expected_value, "encountered invalid Trasfer.value");
+            } else {
+                panic!("encountered unexpected event kind: expected a Transfer event")
+            }
+            let expected_topics = vec![
+                encoded_into_hash(&PrefixedValue {
+                    value: b"Erc20::Transfer",
+                    prefix: b"",
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::from",
+                    value: &expected_from,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::to",
+                    value: &expected_to,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::value",
+                    value: &expected_value,
+                }),
+            ];
+
+            let topics = event.topics.clone();
+            for (n, (actual_topic, expected_topic)) in
+                topics.iter().zip(expected_topics).enumerate()
+            {
+                let mut topic_hash = Hash::CLEAR_HASH;
+                let len = actual_topic.len();
+                topic_hash.as_mut()[0..len].copy_from_slice(&actual_topic[0..len]);
+
+                assert_eq!(
+                    topic_hash, expected_topic,
+                    "encountered invalid topic at {n}"
+                );
+            }
+        }
+
+        /// The default constructor does its job.
+        #[ink::test]
+        fn new_works() {
+            // Constructor works.
+            let _erc20 = Erc20::new(100);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        /// The total supply was applied.
+        #[ink::test]
+        fn total_supply_works() {
+            // Constructor works.
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Get the token total supply.
+            assert_eq!(erc20.total_supply(), 100);
+        }
+
+        /// Get the actual balance of an account.
+        #[ink::test]
+        fn balance_of_works() {
+            // Constructor works
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            // Alice owns all the tokens on contract instantiation
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            // Bob does not owns tokens
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+        }
+
+        #[ink::test]
+        fn transfer_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Alice transfers 10 tokens to Bob.
+            assert_eq!(erc20.transfer(accounts.bob, 10), Ok(()));
+            // Bob owns 10 tokens.
+            assert_eq!(erc20.balance_of(accounts.bob), 10);
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 2);
+            // Check first transfer event related to ERC-20 instantiation.
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Check the second transfer event relating to the actual trasfer.
+            assert_transfer_event(
+                &emitted_events[1],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x02; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn invalid_transfer_should_fail() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+
+            // Set the contract as callee and Bob as caller.
+            let contract = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(contract);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob fails to transfers 10 tokens to Eve.
+            assert_eq!(
+                erc20.transfer(accounts.eve, 10),
+                Err(Error::InsufficientBalance)
+            );
+            // Alice owns all the tokens.
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            assert_eq!(erc20.balance_of(accounts.eve), 0);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 1);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        #[ink::test]
+        fn transfer_from_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            // Bob fails to transfer tokens owned by Alice.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Err(Error::InsufficientAllowance)
+            );
+            // Alice approves Bob for token transfers on her behalf.
+            assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));
+
+            // The approve event takes place.
+            assert_eq!(ink::env::test::recorded_events().count(), 2);
+
+            // Set the contract as callee and Bob as caller.
+            let contract = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(contract);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob transfers tokens from Alice to Eve.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Ok(())
+            );
+            // Eve owns tokens.
+            assert_eq!(erc20.balance_of(accounts.eve), 10);
+
+            // Check all transfer events that happened during the previous calls:
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 3);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // The second event `emitted_events[1]` is an Approve event that we skip
+            // checking.
+            assert_transfer_event(
+                &emitted_events[2],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x05; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn allowance_must_not_change_on_failed_transfer() {
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            // Alice approves Bob for token transfers on her behalf.
+            let alice_balance = erc20.balance_of(accounts.alice);
+            let initial_allowance = alice_balance + 2;
+            assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
+
+            // Get contract address.
+            let callee = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(callee);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob tries to transfer tokens from Alice to Eve.
+            let emitted_events_before = ink::env::test::recorded_events().count();
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, alice_balance + 1),
+                Err(Error::InsufficientBalance)
+            );
+            // Allowance must have stayed the same
+            assert_eq!(
+                erc20.allowance(accounts.alice, accounts.bob),
+                initial_allowance
+            );
+            // No more events must have been emitted
+            assert_eq!(
+                emitted_events_before,
+                ink::env::test::recorded_events().count()
+            )
+        }
+
+        /// For calculating the event topic hash.
+        struct PrefixedValue<'a, 'b, T> {
+            pub prefix: &'a [u8],
+            pub value: &'b T,
+        }
+
+        impl<X> scale::Encode for PrefixedValue<'_, '_, X>
+        where
+            X: scale::Encode,
+        {
+            #[inline]
+            fn size_hint(&self) -> usize {
+                self.prefix.size_hint() + self.value.size_hint()
+            }
+
+            #[inline]
+            fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
+                self.prefix.encode_to(dest);
+                self.value.encode_to(dest);
+            }
+        }
+
+        fn encoded_into_hash<T>(entity: &T) -> Hash
+        where
+            T: scale::Encode,
+        {
+            use ink::{
+                env::hash::{
+                    Blake2x256,
+                    CryptoHash,
+                    HashOutput,
+                },
+                primitives::Clear,
+            };
+
+            let mut result = Hash::CLEAR_HASH;
+            let len_result = result.as_ref().len();
+            let encoded = entity.encode();
+            let len_encoded = encoded.len();
+            if len_encoded <= len_result {
+                result.as_mut()[..len_encoded].copy_from_slice(&encoded);
+                return result
+            }
+            let mut hash_output =
+                <<Blake2x256 as HashOutput>::Type as Default>::default();
+            <Blake2x256 as CryptoHash>::hash(&encoded, &mut hash_output);
+            let copy_len = core::cmp::min(hash_output.len(), len_result);
+            result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
+            result
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn e2e_transfer(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let total_supply = 1_000_000_000;
+            let constructor = Erc20Ref::new(total_supply);
+            let contract_acc_id = client
+                .instantiate("erc20", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // when
+            let total_supply_msg = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.total_supply());
+            let total_supply_res = client
+                .call_dry_run(&ink_e2e::bob(), &total_supply_msg, 0, None)
+                .await;
+
+            let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
+            let transfer_to_bob = 500_000_000u128;
+            let transfer = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.transfer(bob_account.clone(), transfer_to_bob));
+            let _transfer_res = client
+                .call(&ink_e2e::alice(), transfer, 0, None)
+                .await
+                .expect("transfer failed");
+
+            let balance_of = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.balance_of(bob_account));
+            let balance_of_res = client
+                .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
+                .await;
+
+            // then
+            assert_eq!(
+                total_supply,
+                total_supply_res.return_value(),
+                "total_supply"
+            );
+            assert_eq!(transfer_to_bob, balance_of_res.return_value(), "balance_of");
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn e2e_allowances(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let total_supply = 1_000_000_000;
+            let constructor = Erc20Ref::new(total_supply);
+            let contract_acc_id = client
+                .instantiate("erc20", &ink_e2e::bob(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // when
+
+            let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
+            let charlie_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Charlie);
+
+            let amount = 500_000_000u128;
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(
+                        bob_account.clone(),
+                        charlie_account.clone(),
+                        amount,
+                    )
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+
+            assert!(
+                transfer_from_result.is_err(),
+                "unapproved transfer_from should fail"
+            );
+
+            // Bob approves Charlie to transfer up to amount on his behalf
+            let approved_value = 1_000u128;
+            let approve_call = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.approve(charlie_account.clone(), approved_value));
+            client
+                .call(&ink_e2e::bob(), approve_call, 0, None)
+                .await
+                .expect("approve failed");
+
+            // `transfer_from` the approved amount
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(
+                        bob_account.clone(),
+                        charlie_account.clone(),
+                        approved_value,
+                    )
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+            assert!(
+                transfer_from_result.is_ok(),
+                "approved transfer_from should succeed"
+            );
+
+            let balance_of = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.balance_of(bob_account));
+            let balance_of_res = client
+                .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
+                .await;
+
+            // `transfer_from` again, this time exceeding the approved amount
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(bob_account.clone(), charlie_account.clone(), 1)
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+            assert!(
+                transfer_from_result.is_err(),
+                "transfer_from exceeding the approved amount should fail"
+            );
+
+            assert_eq!(
+                total_supply - approved_value,
+                balance_of_res.return_value(),
+                "balance_of"
+            );
+
+            Ok(())
+        }
+    }
+}

--- a/frame/ethink/Cargo.toml
+++ b/frame/ethink/Cargo.toml
@@ -7,22 +7,22 @@ edition.workspace = true
 
 [dependencies]
 ethereum.workspace = true
-ethereum-types = { workspace = true, default-features = false }
-scale-codec = { workspace = true, default-features = false }
-scale-info = { workspace = true, default-features = false }
+ethereum-types.workspace = true
+scale-codec.workspace = true
+scale-info.workspace = true
 # Substrate
-frame-support = { workspace = true, default-features = false }
-frame-system = { workspace = true, default-features = false }
-sp-io = { workspace = true, default-features = false }
-sp-runtime = { workspace = true, default-features = false }
-sp-std = { workspace = true, default-features = false }
-sp-core = { workspace = true, default-features = false }
+frame-support.workspace = true
+frame-system.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+sp-std.workspace = true
+sp-core.workspace = true
 log.workspace = true
 
 [dev-dependencies]
-hex = { workspace = true, default-features = false }
+hex.workspace = true
 libsecp256k1 = { workspace = true, features = ["static-context", "hmac"] }
-rlp = { workspace = true, default-features = false }
+rlp.workspace = true
 # Substrate
 pallet-balances = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }

--- a/frame/ethink/src/lib.rs
+++ b/frame/ethink/src/lib.rs
@@ -200,7 +200,6 @@ pub mod pallet {
             // Increase nonce of the sender account
             System::<T>::inc_account_nonce(from);
             // Compose proper destination pallet call
-            // TODO add test for gas_limit
             let call = T::Contracts::build_call(to, value, data, gas_limit)
                 .ok_or(Error::<T>::TxNotSupported)?;
             // Make call

--- a/template/node/tests/common/macros.rs
+++ b/template/node/tests/common/macros.rs
@@ -53,12 +53,12 @@ macro_rules! rpc_rq {
 /// Prepare node and contract for testing env
 #[macro_export]
 macro_rules! prepare_node_and_contract {
-    ( $manifest:ident ) => {
-        prepare::node_and_contract($manifest, None).await
+    ( $manifest:ident, $args:expr ) => {
+        prepare::node_and_contract($manifest, $args, None).await
     };
 
-    ( $manifest:ident, $signer:ident ) => {
-        prepare::node_and_contract($manifest, Some($signer)).await
+    ( $manifest:ident, $args:expr, $signer:ident ) => {
+        prepare::node_and_contract($manifest, $args, Some($signer)).await
     };
 }
 

--- a/template/node/tests/common/mod.rs
+++ b/template/node/tests/common/mod.rs
@@ -7,6 +7,7 @@ pub mod prepare;
 
 pub const NODE_BIN: &'static str = env!("CARGO_BIN_EXE_ethink-node");
 pub const FLIPPER_PATH: &'static str = env!("FLIPPER_PATH");
+pub const ERC20_PATH: &'static str = env!("ERC20_PATH");
 pub const ALITH_ADDRESS: &'static str = env!("ALITH_ADDRESS");
 pub const ALITH_KEY: &'static str = env!("ALITH_KEY");
 pub const BALTATHAR_ADDRESS: &'static str = env!("BALTATHAR_ADDRESS");

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 /// Spawn a node and deploy a contract to it
 pub async fn node_and_contract<R: subxt::Config>(
     manifest_path: &str,
+    constructor_args: Option<&str>,
     signer: Option<&str>,
 ) -> Env<R> {
     let mut builder = TestNodeProcess::<R>::build(NODE_BIN);
@@ -19,7 +20,11 @@ pub async fn node_and_contract<R: subxt::Config>(
     .unwrap_or_else(|err| ::core::panic!("Error spawning ethink-node: {:?}", err));
 
     // deploy contract
-    let output = contracts::deploy(node.url(Protocol::WS).as_str(), manifest_path);
+    let output = contracts::deploy(
+        node.url(Protocol::WS).as_str(),
+        manifest_path,
+        constructor_args,
+    );
     // Look for contract address in the json output
     let rs = Deserializer::from_slice(&output.stdout);
     let contract_address = json_get!(rs["contract"])

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -1,0 +1,56 @@
+//! Integraion tests for ethink!
+#![allow(non_snake_case)]
+
+mod common;
+
+use common::{contracts::ContractInput, eth::EthTxInput, *};
+use ep_crypto::{AccountId20, EthereumSignature};
+use ep_mapping::{SubstrateWeight, Weight};
+use ep_rpc::EthTransaction;
+use ethereum::{
+    EnvelopedEncodable, LegacyTransaction, LegacyTransactionMessage, TransactionSignature,
+};
+use serde_json::{value::Serializer, Deserializer};
+use sp_core::{ecdsa, Pair, U256};
+use sp_runtime::Serialize;
+use ureq::json;
+
+#[tokio::test]
+async fn eth_sendTransaction() {
+    // Spawn node and deploy contract
+    let mut env: Env<PolkadotConfig> =
+        prepare_node_and_contract!(ERC20_PATH, Some("10_000"), BALTATHAR_KEY);
+    // (ERC20 is deployed with 10_000 supply)
+    // Make ETH RPC request (to transfer 2_000 to Alith)
+    let rs = rpc_rq!(env,
+    {
+      "jsonrpc": "2.0",
+      "method": "eth_sendTransaction",
+      "params": [{
+                  "from": BALTATHAR_ADDRESS,
+                  "to": &env.contract_address(),
+                  "data": contracts::encode(ERC20_PATH, "transfer"),
+                  "gas": SubstrateWeight::max()
+                 },
+                 "latest"],
+      "id": 0
+    });
+
+    // Handle response
+    let json = to_json_val!(rs);
+    ensure_no_err!(&json);
+    let _tx_hash = extract_result!(&json);
+    // Wait until tx gets executed
+    let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
+    // Check state
+    let output = contracts::call(&env, "balance_of", Some(ALITH_ADDRESS), false);
+    let rs = Deserializer::from_slice(&output.stdout);
+
+    let res = to_json_val!(rs);
+    println!("RES = {:#?}", &res);
+    panic!()
+    // Should be flipped to `true`
+    // assert!(json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
+    //     .as_bool()
+    //     .expect("can't parse cargo contract output"));
+}


### PR DESCRIPTION
e2e test suites are organized as follows:

+ `flipper` will have tests for all RPC methods running on the simple `flipper.ink` contract
+ `erc20` will test primarily making various calls to `erc20.ink` contract via `ethink-rpc`, 
   meaning that `eth_sendTransaction` and `eth_sendRawTransaction` will be tested more likely than other (non-contract-invocation-related) RPC methods here

(Currently the first added erc20 test fails, need to dig into input data encoding issues)