### PR TITLE
`erc20::transfer()` works!

### DIFF
--- a/dapp/contracts/erc20.ink/lib.rs
+++ b/dapp/contracts/erc20.ink/lib.rs
@@ -175,7 +175,7 @@ mod erc20 {
             let caller = self.env().caller();
             let allowance = self.allowance_impl(&from, &caller);
             if allowance < value {
-                return Err(Error::InsufficientAllowance)
+                return Err(Error::InsufficientAllowance);
             }
             self.transfer_from_to(&from, &to, value)?;
             self.allowances
@@ -199,7 +199,7 @@ mod erc20 {
         ) -> Result<()> {
             let from_balance = self.balance_of_impl(from);
             if from_balance < value {
-                return Err(Error::InsufficientBalance)
+                return Err(Error::InsufficientBalance);
             }
 
             self.balances.insert(from, &(from_balance - value));
@@ -218,10 +218,7 @@ mod erc20 {
     mod tests {
         use super::*;
 
-        use ink::primitives::{
-            Clear,
-            Hash,
-        };
+        use ink::primitives::{Clear, Hash};
 
         type Event = <Erc20 as ::ink::reflect::ContractEventBase>::Type;
 
@@ -322,8 +319,7 @@ mod erc20 {
                 Some(AccountId::from([0x01; 32])),
                 100,
             );
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
             // Alice owns all the tokens on contract instantiation
             assert_eq!(erc20.balance_of(accounts.alice), 100);
             // Bob does not owns tokens
@@ -335,8 +331,7 @@ mod erc20 {
             // Constructor works.
             let mut erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction.
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
 
             assert_eq!(erc20.balance_of(accounts.bob), 0);
             // Alice transfers 10 tokens to Bob.
@@ -366,8 +361,7 @@ mod erc20 {
         fn invalid_transfer_should_fail() {
             // Constructor works.
             let mut erc20 = Erc20::new(100);
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
 
             assert_eq!(erc20.balance_of(accounts.bob), 0);
 
@@ -402,8 +396,7 @@ mod erc20 {
             // Constructor works.
             let mut erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction.
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
 
             // Bob fails to transfer tokens owned by Alice.
             assert_eq!(
@@ -451,8 +444,7 @@ mod erc20 {
         #[ink::test]
         fn allowance_must_not_change_on_failed_transfer() {
             let mut erc20 = Erc20::new(100);
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
 
             // Alice approves Bob for token transfers on her behalf.
             let alice_balance = erc20.balance_of(accounts.alice);
@@ -509,11 +501,7 @@ mod erc20 {
             T: scale::Encode,
         {
             use ink::{
-                env::hash::{
-                    Blake2x256,
-                    CryptoHash,
-                    HashOutput,
-                },
+                env::hash::{Blake2x256, CryptoHash, HashOutput},
                 primitives::Clear,
             };
 
@@ -523,10 +511,9 @@ mod erc20 {
             let len_encoded = encoded.len();
             if len_encoded <= len_result {
                 result.as_mut()[..len_encoded].copy_from_slice(&encoded);
-                return result
+                return result;
             }
-            let mut hash_output =
-                <<Blake2x256 as HashOutput>::Type as Default>::default();
+            let mut hash_output = <<Blake2x256 as HashOutput>::Type as Default>::default();
             <Blake2x256 as CryptoHash>::hash(&encoded, &mut hash_output);
             let copy_len = core::cmp::min(hash_output.len(), len_result);
             result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
@@ -601,14 +588,9 @@ mod erc20 {
             let charlie_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Charlie);
 
             let amount = 500_000_000u128;
-            let transfer_from =
-                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
-                    erc20.transfer_from(
-                        bob_account.clone(),
-                        charlie_account.clone(),
-                        amount,
-                    )
-                });
+            let transfer_from = build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                erc20.transfer_from(bob_account.clone(), charlie_account.clone(), amount)
+            });
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), transfer_from, 0, None)
                 .await;
@@ -628,14 +610,9 @@ mod erc20 {
                 .expect("approve failed");
 
             // `transfer_from` the approved amount
-            let transfer_from =
-                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
-                    erc20.transfer_from(
-                        bob_account.clone(),
-                        charlie_account.clone(),
-                        approved_value,
-                    )
-                });
+            let transfer_from = build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                erc20.transfer_from(bob_account.clone(), charlie_account.clone(), approved_value)
+            });
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), transfer_from, 0, None)
                 .await;
@@ -651,10 +628,8 @@ mod erc20 {
                 .await;
 
             // `transfer_from` again, this time exceeding the approved amount
-            let transfer_from =
-                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
-                    erc20.transfer_from(bob_account.clone(), charlie_account.clone(), 1)
-                });
+            let transfer_from = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.transfer_from(bob_account.clone(), charlie_account.clone(), 1));
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), transfer_from, 0, None)
                 .await;

--- a/template/node/tests/common/contracts.rs
+++ b/template/node/tests/common/contracts.rs
@@ -33,14 +33,12 @@ impl Into<Vec<u8>> for ContractInput {
 pub fn deploy(
     url: &str,
     manifest_path: &str,
-    args: Option<&str>,
+    args: Option<Vec<&str>>,
     signer: Option<&str>,
 ) -> process::Output {
     let surl_arg = &format!("-s={}", signer.unwrap_or(ALITH_KEY));
     let manifest_arg = format!("--manifest-path={manifest_path}");
     let url_arg = format!("--url={}", url);
-    // TODO
-    let mut args_arg = String::new();
 
     let mut cmd_args = vec![
         "contract",
@@ -53,9 +51,13 @@ pub fn deploy(
         "--output-json",
     ];
 
-    if let Some(args) = args {
-        args_arg = format!("--args={args}");
-        cmd_args.push(&args_arg)
+    let args = args
+        .unwrap_or(vec![])
+        .iter()
+        .map(|a| format!("--args={a}"))
+        .collect::<Vec<_>>();
+    for s in &args {
+        cmd_args.push(s)
     }
 
     process::Command::new("cargo")
@@ -64,11 +66,11 @@ pub fn deploy(
         .expect("failed to instantiate with cargo-contract")
 }
 
-/// Call contract on the node exposed via `url`, and return the output
+/// Call contract deployed to env, and return the output
 pub fn call(
     env: &Env<PolkadotConfig>,
     msg: &str,
-    args: Option<&str>,
+    args: Option<Vec<&str>>,
     execute: bool,
     signer: Option<&str>,
 ) -> process::Output {
@@ -77,8 +79,6 @@ pub fn call(
     let url_arg = &format!("--url={}", env.ws_url());
     let contract_arg = &format!("--contract={}", env.contract.address);
     let msg_arg = &format!("--message={msg}");
-    // TODO multi args like in encode() below
-    let mut args_arg = String::new();
 
     let mut cmd_args = vec![
         "contract",
@@ -91,9 +91,13 @@ pub fn call(
         "--output-json",
     ];
 
-    if let Some(args) = args {
-        args_arg = format!("--args={args}");
-        cmd_args.push(&args_arg)
+    let args = args
+        .unwrap_or(vec![])
+        .iter()
+        .map(|a| format!("--args={a}"))
+        .collect::<Vec<_>>();
+    for s in &args {
+        cmd_args.push(s)
     }
 
     if execute {

--- a/template/node/tests/common/contracts.rs
+++ b/template/node/tests/common/contracts.rs
@@ -1,4 +1,7 @@
-use crate::{common::*, Serialize};
+use crate::{
+    common::{consts::*, *},
+    Serialize,
+};
 use serde::Serializer;
 use std::{
     io::{BufRead, BufReader},

--- a/template/node/tests/common/eth.rs
+++ b/template/node/tests/common/eth.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ecdsa, ContractInput, EthTransaction, EthereumSignature, LegacyTransaction,
+    common::contracts::ContractInput, ecdsa, EthTransaction, EthereumSignature, LegacyTransaction,
     LegacyTransactionMessage, SubstrateWeight, TransactionSignature, Weight, U256,
 };
 

--- a/template/node/tests/common/macros.rs
+++ b/template/node/tests/common/macros.rs
@@ -73,3 +73,16 @@ macro_rules! make_rq {
         )
     };
 }
+
+#[macro_export]
+macro_rules! call {
+    ($env:ident, $msg:literal, $args:expr) => {
+        contracts::call(&$env, $msg, $args, false, None)
+    };
+    ($env:ident, $msg:literal, $args:expr, $exec:literal) => {
+        contracts::call(&$env, $msg, $args, $exec, None)
+    };
+    ($env:ident, $msg:literal, $args:expr, $exec:literal, $signer:expr) => {
+        contracts::call(&$env, $msg, $args, $exec, $signer)
+    };
+}

--- a/template/node/tests/common/macros.rs
+++ b/template/node/tests/common/macros.rs
@@ -76,6 +76,9 @@ macro_rules! make_rq {
 
 #[macro_export]
 macro_rules! call {
+    ($env:ident, $msg:literal) => {
+        contracts::call(&$env, $msg, None, false, None)
+    };
     ($env:ident, $msg:literal, $args:expr) => {
         contracts::call(&$env, $msg, $args, false, None)
     };

--- a/template/node/tests/common/macros.rs
+++ b/template/node/tests/common/macros.rs
@@ -86,3 +86,13 @@ macro_rules! call {
         contracts::call(&$env, $msg, $args, $exec, $signer)
     };
 }
+
+#[macro_export]
+macro_rules! encode {
+    ($path:ident, $msg:literal) => {
+        contracts::encode($path, $msg, None)
+    };
+    ($path:ident, $msg:literal, $args:expr) => {
+        contracts::encode($path, $msg, $args)
+    };
+}

--- a/template/node/tests/common/mod.rs
+++ b/template/node/tests/common/mod.rs
@@ -5,13 +5,13 @@ pub mod contracts;
 pub mod eth;
 pub mod prepare;
 
-pub const NODE_BIN: &'static str = env!("CARGO_BIN_EXE_ethink-node");
-pub const FLIPPER_PATH: &'static str = env!("FLIPPER_PATH");
-pub const ERC20_PATH: &'static str = env!("ERC20_PATH");
-pub const ALITH_ADDRESS: &'static str = env!("ALITH_ADDRESS");
-pub const ALITH_KEY: &'static str = env!("ALITH_KEY");
-pub const BALTATHAR_ADDRESS: &'static str = env!("BALTATHAR_ADDRESS");
-pub const BALTATHAR_KEY: &'static str = env!("BALTATHAR_KEY");
+pub mod consts {
+    pub const NODE_BIN: &'static str = env!("CARGO_BIN_EXE_ethink-node");
+    pub const ALITH_ADDRESS: &'static str = env!("ALITH_ADDRESS");
+    pub const ALITH_KEY: &'static str = env!("ALITH_KEY");
+    pub const BALTATHAR_ADDRESS: &'static str = env!("BALTATHAR_ADDRESS");
+    pub const BALTATHAR_KEY: &'static str = env!("BALTATHAR_KEY");
+}
 
 use crate::AccountId20;
 use node::{Protocol, TestNodeProcess};

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 /// Spawn a node and deploy a contract to it
 pub async fn node_and_contract<R: subxt::Config>(
     manifest_path: &str,
-    constructor_args: Option<&str>,
+    constructor_args: Option<Vec<&str>>,
     signer: Option<&str>,
 ) -> Env<R> {
     let mut builder = TestNodeProcess::<R>::build(NODE_BIN);

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -1,5 +1,5 @@
 //! Prelude actions needed in most of the tests
-use crate::{node::*, *};
+use crate::common::{consts::*, node::*, *};
 use serde_json::Deserializer;
 use std::str::FromStr;
 

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -24,6 +24,7 @@ pub async fn node_and_contract<R: subxt::Config>(
         node.url(Protocol::WS).as_str(),
         manifest_path,
         constructor_args,
+        signer,
     );
     // Look for contract address in the json output
     let rs = Deserializer::from_slice(&output.stdout);

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{*, consts::*};
+use common::{consts::*, *};
 use ep_crypto::{AccountId20, EthereumSignature};
 use ep_mapping::{SubstrateWeight, Weight};
 use ep_rpc::EthTransaction;
@@ -42,7 +42,7 @@ async fn transfer_works() {
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state
-    let output = call!(env, "balance_of", Some(ALITH_ADDRESS));
+    let output = call!(env, "balance_of", Some(vec![ALITH_ADDRESS]));
     let rs = Deserializer::from_slice(&output.stdout);
     // Alith balance should become 2_000
     assert_eq!(

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -22,7 +22,7 @@ async fn transfer_works() {
         prepare_node_and_contract!(ERC20_PATH, Some("10_000"), BALTATHAR_KEY);
     // (ERC20 is deployed with 10_000 supply)
     // Make ETH RPC request (to transfer 2_000 to Alith)
-    let call_data = contracts::encode(ERC20_PATH, "transfer", Some(vec![ALITH_ADDRESS, "2_000"]));
+    let call_data = encode!(ERC20_PATH, "transfer", Some(vec![ALITH_ADDRESS, "2_000"]));
     let rs = rpc_rq!(env,
     {
       "jsonrpc": "2.0",

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -16,12 +16,13 @@ use sp_runtime::Serialize;
 use ureq::json;
 
 #[tokio::test]
-async fn eth_sendTransaction() {
+async fn transfer_works() {
     // Spawn node and deploy contract
     let mut env: Env<PolkadotConfig> =
         prepare_node_and_contract!(ERC20_PATH, Some("10_000"), BALTATHAR_KEY);
     // (ERC20 is deployed with 10_000 supply)
     // Make ETH RPC request (to transfer 2_000 to Alith)
+    let call_data = contracts::encode(ERC20_PATH, "transfer", Some(vec![ALITH_ADDRESS, "2_000"]));
     let rs = rpc_rq!(env,
     {
       "jsonrpc": "2.0",
@@ -29,13 +30,12 @@ async fn eth_sendTransaction() {
       "params": [{
                   "from": BALTATHAR_ADDRESS,
                   "to": &env.contract_address(),
-                  "data": contracts::encode(ERC20_PATH, "transfer"),
+                  "data": call_data,
                   "gas": SubstrateWeight::max()
                  },
                  "latest"],
       "id": 0
     });
-
     // Handle response
     let json = to_json_val!(rs);
     ensure_no_err!(&json);
@@ -43,14 +43,20 @@ async fn eth_sendTransaction() {
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state
-    let output = contracts::call(&env, "balance_of", Some(ALITH_ADDRESS), false);
+    let output = contracts::call(
+        &env,
+        "balance_of",
+        Some(ALITH_ADDRESS),
+        false,
+        Some(ALITH_KEY),
+    );
     let rs = Deserializer::from_slice(&output.stdout);
-
-    let res = to_json_val!(rs);
-    println!("RES = {:#?}", &res);
-    panic!()
-    // Should be flipped to `true`
-    // assert!(json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
-    //     .as_bool()
-    //     .expect("can't parse cargo contract output"));
+    // Alith balance should become 2_000
+    assert_eq!(
+        json_get!(rs["data"]["Tuple"]["values"][0]["UInt"])
+            .as_number()
+            .expect("can't parse cargo contract output")
+            .as_u64(),
+        Some(2_000u64)
+    );
 }

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -43,13 +43,7 @@ async fn transfer_works() {
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state
-    let output = contracts::call(
-        &env,
-        "balance_of",
-        Some(ALITH_ADDRESS),
-        false,
-        Some(ALITH_KEY),
-    );
+    let output = call!(env, "balance_of", Some(ALITH_ADDRESS));
     let rs = Deserializer::from_slice(&output.stdout);
     // Alith balance should become 2_000
     assert_eq!(

--- a/template/node/tests/erc20.rs
+++ b/template/node/tests/erc20.rs
@@ -3,17 +3,16 @@
 
 mod common;
 
-use common::{contracts::ContractInput, eth::EthTxInput, *};
+use common::{*, consts::*};
 use ep_crypto::{AccountId20, EthereumSignature};
 use ep_mapping::{SubstrateWeight, Weight};
 use ep_rpc::EthTransaction;
-use ethereum::{
-    EnvelopedEncodable, LegacyTransaction, LegacyTransactionMessage, TransactionSignature,
-};
-use serde_json::{value::Serializer, Deserializer};
-use sp_core::{ecdsa, Pair, U256};
+use ethereum::{LegacyTransaction, LegacyTransactionMessage, TransactionSignature};
+use serde_json::Deserializer;
+use sp_core::{ecdsa, U256};
 use sp_runtime::Serialize;
-use ureq::json;
+
+pub const ERC20_PATH: &'static str = env!("ERC20_PATH");
 
 #[tokio::test]
 async fn transfer_works() {

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{eth::EthTxInput, consts::*, *};
+use common::{consts::*, eth::EthTxInput, *};
 use ep_crypto::{AccountId20, EthereumSignature};
 use ep_mapping::{SubstrateWeight, Weight};
 use ep_rpc::EthTransaction;
@@ -20,7 +20,8 @@ pub const FLIPPER_PATH: &'static str = env!("FLIPPER_PATH");
 #[tokio::test]
 async fn eth_sendRawTransaction() {
     // Spawn node and deploy contract
-    let mut env: Env<PolkadotConfig> = prepare_node_and_contract!(FLIPPER_PATH, Some("false"));
+    let mut env: Env<PolkadotConfig> =
+        prepare_node_and_contract!(FLIPPER_PATH, Some(vec!["false"]));
     // (Flipper is deployed with `false` state)
     let input = EthTxInput {
         signer: ecdsa::Pair::from_string(ALITH_KEY, None).unwrap(),
@@ -57,7 +58,7 @@ async fn eth_sendRawTransaction() {
 async fn eth_sendTransaction() {
     // Spawn node and deploy contract
     let mut env: Env<PolkadotConfig> =
-        prepare_node_and_contract!(FLIPPER_PATH, Some("false"), BALTATHAR_KEY);
+        prepare_node_and_contract!(FLIPPER_PATH, Some(vec!["false"]), BALTATHAR_KEY);
     // (Flipper is deployed with `false` state)
     // Make ETH RPC request (to flip it to `true`)
     let rs = rpc_rq!(env,
@@ -81,7 +82,7 @@ async fn eth_sendTransaction() {
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state
-    let output = call!(env, "get", None);
+    let output = call!(env, "get");
     let rs = Deserializer::from_slice(&output.stdout);
     // Should be flipped to `true`
     assert!(json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
@@ -93,7 +94,7 @@ async fn eth_sendTransaction() {
 async fn gas_limit_is_respected() {
     // Spawn node and deploy contract
     let mut env: Env<PolkadotConfig> =
-        prepare_node_and_contract!(FLIPPER_PATH, Some("false"), BALTATHAR_KEY);
+        prepare_node_and_contract!(FLIPPER_PATH, Some(vec!["false"]), BALTATHAR_KEY);
     // (Flipper is deployed with `false` state)
     // Make ETH RPC request (to flip it to `true`)
     // Insufficient gas_limit (None => 0)
@@ -166,7 +167,8 @@ async fn gas_limit_is_respected() {
 #[tokio::test]
 async fn eth_call() {
     // Spawn node and deploy contract
-    let mut env: Env<PolkadotConfig> = prepare_node_and_contract!(FLIPPER_PATH, Some("false"));
+    let mut env: Env<PolkadotConfig> =
+        prepare_node_and_contract!(FLIPPER_PATH, Some(vec!["false"]));
     // (Flipper is deployed with `false` state)
     // Make eth_call rpc request to get() flipper state
     let rq = json!({
@@ -204,7 +206,7 @@ async fn eth_call() {
 #[tokio::test]
 async fn eth_estimateGas() {
     // Spawn node and deploy contract
-    let env: Env<PolkadotConfig> = prepare_node_and_contract!(FLIPPER_PATH, Some("false"));
+    let env: Env<PolkadotConfig> = prepare_node_and_contract!(FLIPPER_PATH, Some(vec!["false"]));
     // Retrieve gas estimation via cargo-contract dry-run
     let output = call!(env, "flip");
     let rs = Deserializer::from_slice(&output.stdout);

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -23,7 +23,7 @@ async fn eth_sendRawTransaction() {
     let input = EthTxInput {
         signer: ecdsa::Pair::from_string(ALITH_KEY, None).unwrap(),
         action: ethereum::TransactionAction::Call(env.contract_address().into()),
-        data: contracts::encode(FLIPPER_PATH, "flip", None),
+        data: encode!(FLIPPER_PATH, "flip"),
         ..Default::default()
     };
     let tx = eth::compose_and_sign_tx(input);
@@ -65,8 +65,7 @@ async fn eth_sendTransaction() {
       "params": [{
                   "from": BALTATHAR_ADDRESS,
                   "to": &env.contract_address(),
-                  // TODO encode
-                  "data": contracts::encode(FLIPPER_PATH, "flip", None),
+                  "data": encode!(FLIPPER_PATH, "flip"),
                   "gas": SubstrateWeight::max()
                  },
                  "latest"],
@@ -103,7 +102,7 @@ async fn gas_limit_is_respected() {
       "params": [{
                   "from": BALTATHAR_ADDRESS,
                   "to": &env.contract_address(),
-                  "data": contracts::encode(FLIPPER_PATH, "flip", None)
+                  "data": encode!(FLIPPER_PATH, "flip")
                  },
                  "latest"],
       "id": 0
@@ -141,7 +140,7 @@ async fn gas_limit_is_respected() {
       "params": [{
                   "from": BALTATHAR_ADDRESS,
                   "to": &env.contract_address(),
-                  "data": contracts::encode(FLIPPER_PATH, "flip", None),
+                  "data": encode!(FLIPPER_PATH, "flip"),
                   "gas": half_weight_consumed,
                  },
                  "latest"],
@@ -174,7 +173,7 @@ async fn eth_call() {
        "params": [{
                       "from": ALITH_ADDRESS,
                       "to": &env.contract_address(),
-                      "data": contracts::encode(FLIPPER_PATH, "get", None),
+                      "data": encode!(FLIPPER_PATH, "get"),
                       "gas": SubstrateWeight::max()
                   },
                   "latest"],
@@ -219,7 +218,7 @@ async fn eth_estimateGas() {
        "params": [{
                       "from": ALITH_ADDRESS,
                       "to": &env.contract_address(),
-                      "data": contracts::encode(FLIPPER_PATH, "flip", None)
+                      "data": encode!(FLIPPER_PATH, "flip")
                   },
                   "latest"],
        "id": 0

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -43,7 +43,7 @@ async fn eth_sendRawTransaction() {
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state
-    let output = call!(env, "get", None);
+    let output = call!(env, "get");
     let rs = Deserializer::from_slice(&output.stdout);
     // Should be flipped to `true`
     assert!(json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
@@ -114,7 +114,7 @@ async fn gas_limit_is_respected() {
     // Wait until tx fails (or timeout)
     let _ = &env.wait_for_event("system.ExtrinsicFailed", 2).await;
     // Check state
-    let output = call!(env, "get", None);
+    let output = call!(env, "get");
     let rs = Deserializer::from_slice(&output.stdout);
     // Should stay flipped to `false` as tx should have failed with insuficcient gas
     assert!(!json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
@@ -123,7 +123,7 @@ async fn gas_limit_is_respected() {
 
     // Now let's set gas_limit to be half of the amount estimated
     // Retrieve gas estimation via cargo-contract dry-run
-    let output = call!(env, "flip", None);
+    let output = call!(env, "flip");
     let rs = Deserializer::from_slice(&output.stdout);
     let gas_consumed = json_get!(rs["gas_consumed"]).to_owned();
     let half_weight_consumed = serde_json::from_value::<Weight>(gas_consumed)
@@ -153,7 +153,7 @@ async fn gas_limit_is_respected() {
     // Wait until tx fails (or timeout)
     let _ = &env.wait_for_event("system.ExtrinsicFailed", 2).await;
     // Check state
-    let output = call!(env, "get", None);
+    let output = call!(env, "get");
     let rs = Deserializer::from_slice(&output.stdout);
     // Should stay flipped to `false` as tx should have failed with insuficcient gas
     assert!(!json_get!(rs["data"]["Tuple"]["values"][0]["Bool"])
@@ -204,7 +204,7 @@ async fn eth_estimateGas() {
     // Spawn node and deploy contract
     let env: Env<PolkadotConfig> = prepare_node_and_contract!(FLIPPER_PATH, Some("false"));
     // Retrieve gas estimation via cargo-contract dry-run
-    let output = call!(env, "flip", None, false);
+    let output = call!(env, "flip");
     let rs = Deserializer::from_slice(&output.stdout);
     let gas_consumed = json_get!(rs["gas_consumed"]).to_owned();
     let weight = serde_json::from_value::<Weight>(gas_consumed)

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{contracts::ContractInput, eth::EthTxInput, *};
+use common::{eth::EthTxInput, consts::*, *};
 use ep_crypto::{AccountId20, EthereumSignature};
 use ep_mapping::{SubstrateWeight, Weight};
 use ep_rpc::EthTransaction;
@@ -14,6 +14,8 @@ use serde_json::{value::Serializer, Deserializer};
 use sp_core::{ecdsa, Pair, U256};
 use sp_runtime::Serialize;
 use ureq::json;
+
+pub const FLIPPER_PATH: &'static str = env!("FLIPPER_PATH");
 
 #[tokio::test]
 async fn eth_sendRawTransaction() {


### PR DESCRIPTION
The reason of the first `erc20` e2e test failure (#14 ) turned out to be a [bug](https://github.com/agryaznov/ink/commit/b5de5fa98365af801e66c61bfaa72b846b6cde50) in the forked ink! crate (fixed now). 
_(Basically we don't really need to depend on the fork (for contracts and tooling, ethink! itself does not depend on ink!), as ink allows to use custom environment in contracts. We will migrate to original ink! soon in our example contracts)_ 

+ [X] `erc20::transfer()` test passes,
+ [X] refactored all e2e tests. 

So far ethink! node seems to work fine with erc20 contract. More tests to be added soon.
