### PR TITLE
update to `ink v5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,8 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "scale-decode 0.11.1",
+ "scale-encode 0.6.0",
  "scale-info",
  "serde",
  "sp-core",
@@ -8394,14 +8396,38 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d10dcd57b1c2a3c41c9cf68f71fb09747ada1ea932ad961aca7e2ca28315f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver 0.1.1",
+]
+
+[[package]]
+name = "scale-bits"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "scale-type-resolver",
+ "scale-type-resolver 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc79ba56a1c742f5aeeed1f1801f3edf51f7e818f0a54582cac6f131364ea7b"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits 0.5.0",
+ "scale-decode-derive 0.11.1",
+ "scale-type-resolver 0.1.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -8413,10 +8439,22 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
- "scale-decode-derive",
- "scale-type-resolver",
+ "scale-bits 0.6.0",
+ "scale-decode-derive 0.13.1",
+ "scale-type-resolver 0.2.0",
  "smallvec",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5398fdb3c7bea3cb419bac4983aadacae93fe1a7b5f693f4ebd98c3821aad7a5"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8433,6 +8471,19 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628800925a33794fb5387781b883b5e14d130fece9af5a63613867b8de07c5c7"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-encode-derive 0.6.0",
+ "scale-type-resolver 0.1.1",
+ "smallvec",
+]
+
+[[package]]
+name = "scale-encode"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba0b9c48dc0eb20c60b083c29447c0c4617cb7c4a4c9fef72aa5c5bc539e15e"
@@ -8440,10 +8491,23 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
- "scale-encode-derive",
- "scale-type-resolver",
+ "scale-bits 0.6.0",
+ "scale-encode-derive 0.7.1",
+ "scale-type-resolver 0.2.0",
  "smallvec",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a304e1af7cdfbe7a24e08b012721456cc8cecdedadc14b3d10513eada63233c"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8487,6 +8551,15 @@ dependencies = [
 
 [[package]]
 name = "scale-type-resolver"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b800069bfd43374e0f96f653e0d46882a2cb16d6d961ac43bea80f26c76843"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "scale-type-resolver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
@@ -8520,11 +8593,11 @@ dependencies = [
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
- "scale-bits",
- "scale-decode",
- "scale-encode",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
  "scale-info",
- "scale-type-resolver",
+ "scale-type-resolver 0.2.0",
  "serde",
  "yap",
 ]
@@ -10219,9 +10292,9 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "reconnecting-jsonrpsee-ws-client",
- "scale-bits",
- "scale-decode",
- "scale-encode",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
  "scale-info",
  "scale-value",
  "serde",
@@ -10273,9 +10346,9 @@ dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
- "scale-decode",
- "scale-encode",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
  "scale-info",
  "scale-value",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,8 @@ pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = 
 fp-self-contained = { git = "https://github.com/agryaznov/frontier.git", branch = "polkadot-v1.12.0", default-features = false }
 
 # Local
-ep-crypto = { path = "primitives/crypto", default-features = false }
 ep-eth = { path = "primitives/eth", default-features = false }
 ep-mapping = { path = "primitives/mapping", default-features = false }
-ep-rpc = { path = "primitives/rpc", default-features = false }
 ethink-rpc = { path = "client/rpc", default-features = false }
 ethink-rpc-core = { path = "client/rpc-core", default-features = false }
 ethink-runtime = { path = "template/runtime", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ log = { version = "0.4.19", default-features = false }
 rlp = { version = "0.5.2", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.11.1", default-features = false }
+scale-encode = { version = "0.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ This project is an **experimental** add-on to Polkadot SDK's [pallet-contracts](
 
 ## Quickstart 
 
+Install accustomed cargo-contract tool:
+
+<details>
+<summary>
+Why?
+</summary>
+
+Our 🦆-chain has _pallet-contracts_ on board and at the same time works with _Ethereum_ 20-bytes _Account_ format. The latter fact is required so that our node can understand *MetaMask*-signed transactions. But for the existing _ink!_ contracts tooling this is an unusual setting, as they're expected to work with 32-bytes long _Accounts_.  
+
+For this reason, to work with our *ink!* contracts on this chain, we use a fork of _cargo-contract_ tool which speaks with our node the same language! Run this command to install it: 
+
+</details>
+
+
+``` bash
+cargo install --git https://github.com/agryaznov/cargo-contract --branch ethink --force
+```
+
+
 Run tests:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For this reason, to work with our *ink!* contracts on this chain, we use a fork 
 
 
 ``` bash
-cargo install --git https://github.com/agryaznov/cargo-contract --branch ethink --force
+cargo install --git https://github.com/agryaznov/cargo-contract --branch 4.1.1-ethink --force
 ```
 
 

--- a/dapp/contracts/erc20.ink/Cargo.toml
+++ b/dapp/contracts/erc20.ink/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 [dependencies]
 # TODO update to crates.io with the next ink release
-ink = { path  = "../../../../ink/crates/ink", default-features = false }
-ink_env = { path  = "../../../../ink/crates/env", default-features = false }
+ink = { git = "https://github.com/use-ink/ink", rev = "0cd2b89", default-features = false }
+ink_env = { git = "https://github.com/use-ink/ink", rev = "0cd2b89", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/dapp/contracts/erc20.ink/Cargo.toml
+++ b/dapp/contracts/erc20.ink/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "erc20"
-version = "4.4.0"
+version = "5.0.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "4.3.0", default-features = false }
-ink_env = { version = "4.3.0", default-features = false }
+# TODO update to crates.io with the next ink release
+ink = { path  = "../../../../ink/crates/ink", default-features = false }
+ink_env = { path  = "../../../../ink/crates/env", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/dapp/contracts/flipper.ink/Cargo.toml
+++ b/dapp/contracts/flipper.ink/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "flipper"
-version = "4.4.0"
+version = "5.0.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.3.0", default-features = false }
-ink_env = { version = "4.3.0", default-features = false }
+# TODO update to crates.io with the next ink release
+ink = { path  = "../../../../ink/crates/ink", default-features = false }
+ink_env = { path  = "../../../../ink/crates/env", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
-
-[dev-dependencies]
-ink_e2e = { git = "https://github.com/agryaznov/ink", branch = "ethink" }
 
 [lib]
 path = "lib.rs"

--- a/dapp/contracts/flipper.ink/Cargo.toml
+++ b/dapp/contracts/flipper.ink/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 
 [dependencies]
 # TODO update to crates.io with the next ink release
-ink = { path  = "../../../../ink/crates/ink", default-features = false }
-ink_env = { path  = "../../../../ink/crates/env", default-features = false }
+ink = { git = "https://github.com/use-ink/ink", rev = "0cd2b89", default-features = false }
+ink_env = { git = "https://github.com/use-ink/ink", rev = "0cd2b89", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }

--- a/dapp/contracts/flipper.ink/lib.rs
+++ b/dapp/contracts/flipper.ink/lib.rs
@@ -1,7 +1,21 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-#[ink::contract]
+#[ink::contract(env = EthinkEnvironment)]
 pub mod flipper {
+    // Use custom environmanent with Ethereum-flavored Accountid
+    #[derive(Clone)]
+    pub struct EthinkEnvironment;
+
+    impl ink_env::Environment for EthinkEnvironment {
+        const MAX_EVENT_TOPICS: usize = 3;
+        type AccountId = [u8; 20];
+        type Balance = u128;
+        type Hash = [u8; 32];
+        type Timestamp = u64;
+        type BlockNumber = u32;
+        type ChainExtension = ::ink::env::NoChainExtension;
+    }
+
     #[ink(storage)]
     pub struct Flipper {
         value: bool,

--- a/primitives/eth/Cargo.toml
+++ b/primitives/eth/Cargo.toml
@@ -12,6 +12,8 @@ libsecp256k1.workspace = true
 log.workspace = true
 scale-codec.workspace = true
 scale-info.workspace = true
+scale-decode = { workspace = true, features = ["derive"] }
+scale-encode = { workspace = true, features = ["derive"] }
 ethereum = { workspace = true, features = ["with-codec"] }
 serde = { workspace = true, optional = true }
 hex.workspace = true
@@ -37,6 +39,8 @@ std = [
 	"log/std",
 	"scale-codec/std",
 	"scale-info/std",
+	"scale-encode/std",
+	"scale-decode/std",
 	"impl-serde/std",
 	# Substrate
 	"sp-core/std",

--- a/primitives/eth/src/account.rs
+++ b/primitives/eth/src/account.rs
@@ -31,6 +31,10 @@ use sp_io::hashing::keccak_256;
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode, MaxEncodedLen, TypeInfo,
 )]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_encode::EncodeAsType, scale_decode::DecodeAsType,)
+)]
 pub struct AccountId20(pub [u8; 20]);
 
 impl_serde::impl_fixed_hash_serde!(AccountId20, 20);

--- a/primitives/eth/src/signing.rs
+++ b/primitives/eth/src/signing.rs
@@ -32,6 +32,12 @@ use super::account::AccountId20;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EthereumSignature(pub ecdsa::Signature);
 
+impl From<sp_core::ecdsa::Signature> for EthereumSignature {
+    fn from(s: sp_core::ecdsa::Signature) -> Self {
+        Self(s)
+    }
+}
+
 impl sp_std::fmt::Debug for EthereumSignature {
     fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
         write!(f, "{:02x?}", &self.0 .0)

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -1,13 +1,9 @@
-use ethink_runtime::{
-    AccountId, AuraConfig, Balance, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig, Signature,
-    SudoConfig, SystemConfig, WASM_BINARY,
-};
+use ethink_runtime::{AccountId, RuntimeGenesisConfig, Signature, WASM_BINARY};
 use hex_literal::hex;
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -20,16 +16,6 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
     TPublic::Pair::from_string(&format!("//{}", seed), None)
         .expect("static values are valid; qed")
         .public()
-}
-
-type AccountPublic = <Signature as Verify>::Signer;
-
-/// Generate an account ID from seed.
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
 /// Generate an Aura authority key.
@@ -95,8 +81,6 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
         ))
         .build())
 }
-
-const UNITS: Balance = 1_000_000_000_000_000_000;
 
 /// Configure initial storage state for FRAME modules.
 fn testnet_genesis(

--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -1,12 +1,9 @@
 use crate::{
-    benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
     chain_spec,
-    chain_spec::get_account_id_from_seed,
     cli::{Cli, Subcommand},
     service,
 };
-use ethink_runtime::{Block, ED};
-use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
+use ethink_runtime::Block;
 use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -163,8 +163,7 @@ where
         other: (block_import, grandpa_link, mut telemetry),
     } = new_partial(&config)?;
 
-    let mut net_config =
-        sc_network::config::FullNetworkConfiguration::<_, _, N>::new(&config.network);
+    let net_config = sc_network::config::FullNetworkConfiguration::<_, _, N>::new(&config.network);
     let peer_store_handle = net_config.peer_store_handle();
     let metrics = N::register_notification_metrics(
         config.prometheus_config.as_ref().map(|cfg| &cfg.registry),
@@ -179,7 +178,7 @@ where
         &config.chain_spec,
     );
 
-    let (grandpa_protocol_config, grandpa_notification_service) =
+    let (_grandpa_protocol_config, grandpa_notification_service) =
         sc_consensus_grandpa::grandpa_peers_set_config::<_, N>(
             grandpa_protocol_name.clone(),
             metrics.clone(),

--- a/template/node/tests/common/contracts.rs
+++ b/template/node/tests/common/contracts.rs
@@ -127,7 +127,7 @@ pub fn encode(manifest_path: &str, msg: &str, args: Vec<&str>) -> ContractInput 
     let manifest_arg = &format!("--manifest-path={manifest_path}");
     let msg_arg = &format!("--message={msg}");
 
-    let mut cmd_args = vec!["contract", "encode", manifest_arg, msg_arg,];
+    let mut cmd_args = vec!["contract", "encode", manifest_arg, msg_arg];
 
     let args = args
         .iter()

--- a/template/node/tests/common/contracts.rs
+++ b/template/node/tests/common/contracts.rs
@@ -45,6 +45,7 @@ pub fn deploy(
     let surl_arg = &format!("-s={}", signer.unwrap_or(ALITH_KEY));
     let manifest_arg = format!("--manifest-path={manifest_path}");
     let url_arg = format!("--url={}", url);
+    let config_arg = &format!("--config=Ecdsachain");
 
     let mut cmd_args = vec![
         "contract",
@@ -55,6 +56,7 @@ pub fn deploy(
         "-x",
         "--skip-confirm",
         "--output-json",
+        config_arg,
     ];
 
     let args = args
@@ -84,6 +86,7 @@ pub fn call(
     let url_arg = &format!("--url={}", env.ws_url());
     let contract_arg = &format!("--contract={}", env.contract_address());
     let msg_arg = &format!("--message={msg}");
+    let config_arg = &format!("--config=Ecdsachain");
 
     let mut cmd_args = vec![
         "contract",
@@ -94,6 +97,7 @@ pub fn call(
         contract_arg,
         msg_arg,
         "--output-json",
+        config_arg,
     ];
 
     let args = args
@@ -123,7 +127,7 @@ pub fn encode(manifest_path: &str, msg: &str, args: Vec<&str>) -> ContractInput 
     let manifest_arg = &format!("--manifest-path={manifest_path}");
     let msg_arg = &format!("--message={msg}");
 
-    let mut cmd_args = vec!["contract", "encode", manifest_arg, msg_arg];
+    let mut cmd_args = vec!["contract", "encode", manifest_arg, msg_arg,];
 
     let args = args
         .iter()

--- a/template/node/tests/common/macros.rs
+++ b/template/node/tests/common/macros.rs
@@ -67,8 +67,7 @@ macro_rules! extract_result {
     };
 }
 
-/// Spawn a node, deploy a contract specified with $path to it,
-/// and make post request to its RPC.
+/// Make a request to node's RPC.
 #[macro_export]
 macro_rules! rpc_rq {
     ( $env:ident, $rq:ident ) => {

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -41,6 +41,13 @@ pub async fn node_and_contract<R: subxt::Config>(
         constructor_args,
         signer,
     );
+
+    if !output.status.success() {
+       use std::io::Write;
+       std::io::stdout().write_all(&output.stdout).unwrap();
+       std::io::stderr().write_all(&output.stderr).unwrap();
+       panic!("'cargo contract instantantiate' failed")
+    }
     // Look for contract address in the json output
     let rs = Deserializer::from_slice(&output.stdout);
     let address = json_get!(rs["contract"])

--- a/template/node/tests/common/prepare.rs
+++ b/template/node/tests/common/prepare.rs
@@ -43,10 +43,10 @@ pub async fn node_and_contract<R: subxt::Config>(
     );
 
     if !output.status.success() {
-       use std::io::Write;
-       std::io::stdout().write_all(&output.stdout).unwrap();
-       std::io::stderr().write_all(&output.stderr).unwrap();
-       panic!("'cargo contract instantantiate' failed")
+        use std::io::Write;
+        std::io::stdout().write_all(&output.stdout).unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        panic!("'cargo contract instantantiate' failed")
     }
     // Look for contract address in the json output
     let rs = Deserializer::from_slice(&output.stdout);

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -60,9 +60,9 @@ async fn eth_sendRawTransaction() {
       "id": 0
      });
     // Handle response
-    //    let json = to_json_val!(rs);
-    //    ensure_no_err!(&json);
-    //    let _tx_hash = extract_result!(&json);
+    let json = to_json_val!(rs);
+    ensure_no_err!(&json);
+    let _tx_hash = extract_result!(&json);
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -60,9 +60,9 @@ async fn eth_sendRawTransaction() {
       "id": 0
      });
     // Handle response
-    let json = to_json_val!(rs);
-    ensure_no_err!(&json);
-    let _tx_hash = extract_result!(&json);
+//    let json = to_json_val!(rs);
+//    ensure_no_err!(&json);
+//    let _tx_hash = extract_result!(&json);
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state

--- a/template/node/tests/flipper.rs
+++ b/template/node/tests/flipper.rs
@@ -60,9 +60,9 @@ async fn eth_sendRawTransaction() {
       "id": 0
      });
     // Handle response
-//    let json = to_json_val!(rs);
-//    ensure_no_err!(&json);
-//    let _tx_hash = extract_result!(&json);
+    //    let json = to_json_val!(rs);
+    //    ensure_no_err!(&json);
+    //    let _tx_hash = extract_result!(&json);
     // Wait until tx gets executed
     let _ = &env.wait_for_event("ethink.EthTransactionExecuted", 3).await;
     // Check state


### PR DESCRIPTION
This updates contract fixtures used in e2e tests to use `ink v5` .

_It needs customized cargo-contract [`v4.1.1+ethink`](https://github.com/agryaznov/cargo-contract/releases/tag/4.1.1%2Bethink) to play with the node and to run e2e tests._

_(ethereum primitives have been also updated to be usable from the customized `cargo-contract` and `subxt`)_